### PR TITLE
Add jshint warning codes to posts, for future API access

### DIFF
--- a/_posts/1819-01-01-you-might-be-leaking-a-variable-here.html
+++ b/_posts/1819-01-01-you-might-be-leaking-a-variable-here.html
@@ -3,6 +3,7 @@ title: "You might be leaking a variable ({a}) here"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: W120
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1824-02-01-with-is-not-allowed-in-strict-mode.html
+++ b/_posts/1824-02-01-with-is-not-allowed-in-strict-mode.html
@@ -3,6 +3,7 @@ title: "'with' is not allowed in strict mode"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: E010
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1824-03-01-dont-use-with.html
+++ b/_posts/1824-03-01-dont-use-with.html
@@ -3,6 +3,7 @@ title: "Don't use 'with'"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: W085
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1831-01-01-a-was-used-before-it-was-defined.html
+++ b/_posts/1831-01-01-a-was-used-before-it-was-defined.html
@@ -3,6 +3,7 @@ title: "'{a}' was used before it was defined"
 layout: post
 tags: jslint
 author: jallardice
+jshint_code: W003
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1831-01-02-a-is-not-defined.html
+++ b/_posts/1831-01-02-a-is-not-defined.html
@@ -3,6 +3,7 @@ title: "'{a}' is not defined"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: W117
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1834-01-02-the-object-literal-notation-is-preferrable.html
+++ b/_posts/1834-01-02-the-object-literal-notation-is-preferrable.html
@@ -3,6 +3,7 @@ title: "The object literal notation {} is preferrable"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: W010
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1837-01-02-the-array-literal-notation-is-preferrable.html
+++ b/_posts/1837-01-02-the-array-literal-notation-is-preferrable.html
@@ -3,6 +3,7 @@ title: "The array literal notation [] is preferrable"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: W009
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1844-02-01-unnecessary-semicolon.html
+++ b/_posts/1844-02-01-unnecessary-semicolon.html
@@ -3,6 +3,7 @@ title: "Unnecessary semicolon"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: W032
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1852-01-01-unexpected-a.html
+++ b/_posts/1852-01-01-unexpected-a.html
@@ -2,6 +2,7 @@
 title: "Unexpected '{a}'"
 layout: post
 tags: jslint jshint
+jshint_code: W052
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1854-01-01-unclosed-regular-expression.html
+++ b/_posts/1854-01-01-unclosed-regular-expression.html
@@ -3,6 +3,7 @@ title: "Unclosed regular expression"
 layout: post
 tags: jslint jshint
 author: jallardice
+jshint_code: E015
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1855-01-01-unclosed-comment.html
+++ b/_posts/1855-01-01-unclosed-comment.html
@@ -3,6 +3,7 @@ title: "Unclosed comment"
 layout: post
 tags: jslint jshint
 author: jallardice
+jshint_code: E017
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1856-01-01-unclosed-string.html
+++ b/_posts/1856-01-01-unclosed-string.html
@@ -3,6 +3,7 @@ title: "Unclosed string"
 layout: post
 tags: jslint jshint
 author: jallardice
+jshint_code: W112
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1864-01-01-a-is-better-written-in-dot-notation.html
+++ b/_posts/1864-01-01-a-is-better-written-in-dot-notation.html
@@ -3,6 +3,7 @@ title: "['{a}'] is better written in dot notation"
 layout: post
 tags: jslint jshint
 author: jallardice
+jshint_code: W069
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1865-02-01-strings-must-use-singlequote.html
+++ b/_posts/1865-02-01-strings-must-use-singlequote.html
@@ -3,6 +3,7 @@ title: "Strings must use singlequote"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: W109
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1869-01-01-a-regular-expression-literal-can-be-confused-with.html
+++ b/_posts/1869-01-01-a-regular-expression-literal-can-be-confused-with.html
@@ -3,6 +3,7 @@ title: "A regular expression literal can be confused with '/='"
 layout: post
 tags: jslint jshint
 author: jallardice
+jshint_code: E014
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1871-02-01-did-you-mean-to-return-a-conditional.html
+++ b/_posts/1871-02-01-did-you-mean-to-return-a-conditional.html
@@ -3,6 +3,7 @@ title: "Did you mean to return a conditional instead of an assignment?"
 layout: post
 tags: jshint
 author: jklein
+jshint_code: W093
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1872-01-01-redefinition-of-a.html
+++ b/_posts/1872-01-01-redefinition-of-a.html
@@ -3,6 +3,7 @@ title: "Redefinition of '{a}'"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: W079
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1873-01-01-read-only.html
+++ b/_posts/1873-01-01-read-only.html
@@ -3,6 +3,7 @@ title: "Read only"
 layout: post
 tags: jslint jshint
 author: jallardice
+jshint_code: W020
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1874-01-01-missing-radix-parameter.html
+++ b/_posts/1874-01-01-missing-radix-parameter.html
@@ -3,6 +3,7 @@ title: "Missing radix parameter"
 layout: post
 tags: jslint jshint
 author: jallardice
+jshint_code: W065
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1876-01-01-unexpected-parameter-a-in-get-b-function.html
+++ b/_posts/1876-01-01-unexpected-parameter-a-in-get-b-function.html
@@ -3,6 +3,7 @@ title: "Unexpected parameter '{a}' in get {b} function"
 layout: post
 tags: jslint jshint
 author: jallardice
+jshint_code: W076
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1878-02-01-octal-literals-are-not-allowed-in-strict-mode.html
+++ b/_posts/1878-02-01-octal-literals-are-not-allowed-in-strict-mode.html
@@ -3,6 +3,7 @@ title: "Octal literals are not allowed in strict mode"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: W115
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1881-01-02-a-is-not-a-statement-label.html
+++ b/_posts/1881-01-02-a-is-not-a-statement-label.html
@@ -3,6 +3,7 @@ title: "'{a}' is not a statement label"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: W090
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1884-01-01-do-not-use-a-as-a-constructor.html
+++ b/_posts/1884-01-01-do-not-use-a-as-a-constructor.html
@@ -3,6 +3,7 @@ title: "Do not use {a} as a constructor"
 layout: post
 tags: jslint jshint
 author: jallardice
+jshint_code: W053
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1887-01-02-missing-name-in-function-declaration.html
+++ b/_posts/1887-01-02-missing-name-in-function-declaration.html
@@ -3,6 +3,7 @@ title: "Missing name in function declaration"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: W025
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1890-02-01-mixed-double-and-single-quotes.html
+++ b/_posts/1890-02-01-mixed-double-and-single-quotes.html
@@ -3,6 +3,7 @@ title: "Mixed double and single quotes"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: W110
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1891-02-01-missing-invoking-a-constructor.html
+++ b/_posts/1891-02-01-missing-invoking-a-constructor.html
@@ -3,6 +3,7 @@ title: "Missing '()' invoking a constructor"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: W058
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1898-01-01-a-leading-decimal-point-can-be-confused-with-a-dot-a.html
+++ b/_posts/1898-01-01-a-leading-decimal-point-can-be-confused-with-a-dot-a.html
@@ -3,6 +3,7 @@ title: "A leading decimal point can be confused with a dot: '{a}'"
 layout: post
 tags: jslint jshint
 author: jallardice
+jshint_code: W008
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1900-01-01-use-the-isnan-function-to-compare-with-nan.html
+++ b/_posts/1900-01-01-use-the-isnan-function-to-compare-with-nan.html
@@ -3,6 +3,7 @@ title: "Use the isNaN function to compare with NaN"
 layout: post
 tags: jslint jshint
 author: jallardice
+jshint_code: W019
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1903-01-02-implied-eval-consider-passing-a-function.html
+++ b/_posts/1903-01-02-implied-eval-consider-passing-a-function.html
@@ -3,6 +3,7 @@ title: "Implied eval. Consider passing a function instead of a string"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: W066
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1908-01-02-function-declarations-are-not-invocable.html
+++ b/_posts/1908-01-02-function-declarations-are-not-invocable.html
@@ -3,6 +3,7 @@ title: "Function declarations are not invocable. Wrap the whole function invocat
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: E039
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1909-01-01-dont-make-functions-within-a-loop.html
+++ b/_posts/1909-01-01-dont-make-functions-within-a-loop.html
@@ -3,6 +3,7 @@ title: "Don't make functions within a loop"
 layout: post
 tags: jslint jshint
 author: jallardice
+jshint_code: W083
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1910-01-01-the-function-constructor-is-eval.html
+++ b/_posts/1910-01-01-the-function-constructor-is-eval.html
@@ -3,6 +3,7 @@ title: "The Function constructor is eval"
 layout: post
 tags: jslint jshint
 author: jallardice
+jshint_code: W054
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1910-01-02-the-function-constructor-is-a-form-of-eval.html
+++ b/_posts/1910-01-02-the-function-constructor-is-a-form-of-eval.html
@@ -3,6 +3,7 @@ title: "The Function constructor is a form of eval"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: W054
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1912-01-01-the-body-of-a-for-in-should-be-wrapped-in-an-if-statement.html
+++ b/_posts/1912-01-01-the-body-of-a-for-in-should-be-wrapped-in-an-if-statement.html
@@ -3,6 +3,7 @@ title: "The body of a for in should be wrapped in an if statement to filter unwa
 layout: post
 tags: jslint jshint
 author: jallardice
+jshint_code: W089
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1931-01-01-expected-an-identifier-and-instead-saw-a-a-reserved-word.html
+++ b/_posts/1931-01-01-expected-an-identifier-and-instead-saw-a-a-reserved-word.html
@@ -3,6 +3,7 @@ title: "Expected an identifier and instead saw '{a}' (a reserved word)"
 layout: post
 tags: jslint jshint
 author: jallardice
+jshint_code: W024
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1943-01-02-eval-can-be-harmful.html
+++ b/_posts/1943-01-02-eval-can-be-harmful.html
@@ -3,6 +3,7 @@ title: "eval can be harmful"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: W061
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1944-01-02-es5-option-is-now-set-per-default.html
+++ b/_posts/1944-01-02-es5-option-is-now-set-per-default.html
@@ -3,6 +3,7 @@ title: "ES5 option is now set per default"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: I003
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1948-02-02-duplicate-key-a.html
+++ b/_posts/1948-02-02-duplicate-key-a.html
@@ -3,6 +3,7 @@ title: "Duplicate key '{a}'"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: W075
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1949-01-02-variables-should-not-be-deleted.html
+++ b/_posts/1949-01-02-variables-should-not-be-deleted.html
@@ -3,6 +3,7 @@ title: "Variables should not be deleted"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: W051
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1950-02-02-forgotten-debugger-statement.html
+++ b/_posts/1950-02-02-forgotten-debugger-statement.html
@@ -3,6 +3,7 @@ title: "Forgotten 'debugger' statement?"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: W087
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1950-03-01-a-is-defined-but-never-used.html
+++ b/_posts/1950-03-01-a-is-defined-but-never-used.html
@@ -3,6 +3,7 @@ title: "'{a}' is defined but never used"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: W098
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1954-01-02-a-constructor-name-should-start-with-an-uppercase-letter.html
+++ b/_posts/1954-01-02-a-constructor-name-should-start-with-an-uppercase-letter.html
@@ -3,6 +3,7 @@ title: "A constructor name should start with an uppercase letter"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: W055
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1954-02-01-const-a-has-already-been-declared.html
+++ b/_posts/1954-02-01-const-a-has-already-been-declared.html
@@ -3,6 +3,7 @@ title: "const '{a}' has already been declared"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: E011
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1957-01-01-expected-a-conditional-expression-and-saw-an-assignment.html
+++ b/_posts/1957-01-01-expected-a-conditional-expression-and-saw-an-assignment.html
@@ -3,6 +3,7 @@ title: "Expected a conditional expression and instead saw an assignment."
 layout: post
 tags: jslint jshint
 author: jklein
+jshint_code: W084
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1959-01-01-do-not-wrap-function-literals-in-parens-unless-they-are-immediately-invoked.html
+++ b/_posts/1959-01-01-do-not-wrap-function-literals-in-parens-unless-they-are-immediately-invoked.html
@@ -3,6 +3,7 @@ title: "Do not wrap function literals in parens unless they are to be immediatel
 layout: post
 tags: jslint jshint
 author: jallardice
+jshint_code: W068
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1959-01-02-wrapping-non-iife-function-literals-in-parens.html
+++ b/_posts/1959-01-02-wrapping-non-iife-function-literals-in-parens.html
@@ -3,6 +3,7 @@ title: "Wrapping non-IIFE function literals in parens is unnecessary"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: W068
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1965-01-01-do-not-use-new-for-side-effects.html
+++ b/_posts/1965-01-01-do-not-use-new-for-side-effects.html
@@ -3,6 +3,7 @@ title: "Do not use 'new' for side effects"
 layout: post
 tags: jslint jshint
 author: jallardice
+jshint_code: W031
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1978-01-01-do-not-assign-to-the-exception-parameter.html
+++ b/_posts/1978-01-01-do-not-assign-to-the-exception-parameter.html
@@ -3,6 +3,7 @@ title: "Do not assign to the exception parameter"
 layout: post
 tags: jslint jshint
 author: jallardice
+jshint_code: W022
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1978-03-01-option-validthis-cant-be-used-in-a-global-scope.html
+++ b/_posts/1978-03-01-option-validthis-cant-be-used-in-a-global-scope.html
@@ -3,6 +3,7 @@ title: "Option 'validthis' can't be used in a global scope"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: E009
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/1980-02-01-attempting-to-override-a-which-is-a-constant.html
+++ b/_posts/1980-02-01-attempting-to-override-a-which-is-a-constant.html
@@ -3,6 +3,7 @@ title: "Attempting to override '{a}' which is a constant"
 layout: post
 tags: jshint
 author: jallardice
+jshint_code: E013
 ---
 <p>
     <h3>When do I get this error?</h3>

--- a/_posts/2000-01-01-a-is-a-statement-label.html
+++ b/_posts/2000-01-01-a-is-a-statement-label.html
@@ -3,6 +3,7 @@ title: "'{a}' is a statement label"
 layout: post
 tags: jslint jshint
 author: jallardice
+jshint_code: W037
 ---
 <p>
     <h3>When do I get this error?</h3>


### PR DESCRIPTION
JSHint has useful identifiers for its error messages, which I'm finding very helpful in building tools around jshint. I added them to the posts - this is also really cool for an API feature.
