### PR TITLE
Update website link URL in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,5 +103,5 @@ Property  | Type     | Description
  - Prefer fenced code blocks to traditional indented blocks
  - If an article includes headings they should be of `h3` level and below
 
-[site]: http://jslinterrors.com/
+[site]: http://linterrors.com/
 [gfm]: http://github.github.com/github-flavored-markdown/


### PR DESCRIPTION
The domain linterrors.com was lost so the website now is now at linterrors.com.